### PR TITLE
Don't restart memcached on a config change

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class memcached(
   $max_connections = '8192',
   $verbosity       = undef,
   $unix_socket     = undef,
+  $svc_restart     = true,
   $install_dev     = false
 ) inherits memcached::params {
 
@@ -38,6 +39,12 @@ class memcached(
     enable     => true,
     hasrestart => true,
     hasstatus  => false,
-    subscribe  => File[$memcached::params::config_file],
+  }
+
+  # If restarting we use the notification arrow, otherwise the ordering arrow
+  if $svc_restart {
+    File[$memcached::params::config_file] ~> Service[$memcached::params::service_name]
+  } else {
+    File[$memcached::params::config_file] -> Service[$memcached::params::service_name]
   }
 }


### PR DESCRIPTION
I don't think it's the right thing to do to restart memcached via puppet on a config change. During standard maintenance it'd be nice to have the option to change the config w/o having brief downtime.

For instance we're going to reduce the RAM allocated for caching a bit and introduce a new cluster. That will involve one brief downtime while memcached restarts, and then a "flush" as the new cluster is brought into play. It'd be nicer not to have that restart.

Technically we could get around that config restart by using a branch env on the new servers. Then when the branch is merged into master after the switch to new servers there'd be no restart since the config file hadn't changed. But if we did that, what's the point of the auto-restart? To make things easier in qa which has fewer servers anyway?
